### PR TITLE
refactor: APIレイヤーのリファクタリング - サービス層とユーティリティ層の分離

### DIFF
--- a/src/hooks/useInvitations.ts
+++ b/src/hooks/useInvitations.ts
@@ -1,0 +1,201 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { invitationService } from '@/services/invitationService'
+import {
+  PartnerInvitation,
+  CreateInvitationRequest,
+  CreateInvitationResponse,
+  GetInvitationResponse,
+  AcceptInvitationResponse,
+} from '@/lib/types/partner-invitation'
+import { getErrorMessage } from '@/utils/invitationUtils'
+
+/**
+ * 招待機能のカスタムフック
+ * 招待の状態管理とAPI操作を担当
+ */
+export function useInvitations() {
+  const [invitations, setInvitations] = useState<PartnerInvitation[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  /**
+   * エラーをクリア
+   */
+  const clearError = useCallback(() => {
+    setError(null)
+  }, [])
+
+  /**
+   * 招待一覧を取得
+   */
+  const fetchInvitations = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await invitationService.getInvitations()
+      setInvitations(data)
+    } catch (err) {
+      const errorMessage = getErrorMessage(err)
+      setError(errorMessage)
+      console.error('招待一覧の取得に失敗:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  /**
+   * 新しい招待を作成
+   */
+  const createInvitation = useCallback(async (
+    request: CreateInvitationRequest
+  ): Promise<CreateInvitationResponse | null> => {
+    try {
+      setLoading(true)
+      setError(null)
+      const response = await invitationService.createInvitation(request)
+      // 招待一覧を再取得
+      await fetchInvitations()
+      return response
+    } catch (err) {
+      const errorMessage = getErrorMessage(err)
+      setError(errorMessage)
+      console.error('招待の作成に失敗:', err)
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [fetchInvitations])
+
+  /**
+   * 招待をキャンセル
+   */
+  const cancelInvitation = useCallback(async (invitationId: string): Promise<boolean> => {
+    try {
+      setLoading(true)
+      setError(null)
+      await invitationService.cancelInvitation(invitationId)
+      // 招待一覧を再取得
+      await fetchInvitations()
+      return true
+    } catch (err) {
+      const errorMessage = getErrorMessage(err)
+      setError(errorMessage)
+      console.error('招待のキャンセルに失敗:', err)
+      return false
+    } finally {
+      setLoading(false)
+    }
+  }, [fetchInvitations])
+
+  /**
+   * 期限切れの招待を削除
+   */
+  const cleanupExpiredInvitations = useCallback(async (): Promise<boolean> => {
+    try {
+      setLoading(true)
+      setError(null)
+      await invitationService.cleanupExpiredInvitations()
+      // 招待一覧を再取得
+      await fetchInvitations()
+      return true
+    } catch (err) {
+      const errorMessage = getErrorMessage(err)
+      setError(errorMessage)
+      console.error('期限切れ招待の削除に失敗:', err)
+      return false
+    } finally {
+      setLoading(false)
+    }
+  }, [fetchInvitations])
+
+  // 初回マウント時に招待一覧を取得
+  useEffect(() => {
+    fetchInvitations()
+  }, [fetchInvitations])
+
+  return {
+    invitations,
+    loading,
+    error,
+    clearError,
+    fetchInvitations,
+    createInvitation,
+    cancelInvitation,
+    cleanupExpiredInvitations,
+  }
+}
+
+/**
+ * 単一の招待を管理するカスタムフック
+ */
+export function useInvitation(inviteCode: string) {
+  const [invitation, setInvitation] = useState<GetInvitationResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  /**
+   * エラーをクリア
+   */
+  const clearError = useCallback(() => {
+    setError(null)
+  }, [])
+
+  /**
+   * 招待情報を取得
+   */
+  const fetchInvitation = useCallback(async () => {
+    if (!inviteCode) return
+
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await invitationService.getInvitation(inviteCode)
+      setInvitation(data)
+    } catch (err) {
+      const errorMessage = getErrorMessage(err)
+      setError(errorMessage)
+      console.error('招待情報の取得に失敗:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [inviteCode])
+
+  /**
+   * 招待を受諾
+   */
+  const acceptInvitation = useCallback(async (): Promise<AcceptInvitationResponse | null> => {
+    if (!inviteCode) return null
+
+    try {
+      setLoading(true)
+      setError(null)
+      const response = await invitationService.acceptInvitation(inviteCode)
+      // 招待情報を再取得
+      await fetchInvitation()
+      return response
+    } catch (err) {
+      const errorMessage = getErrorMessage(err)
+      setError(errorMessage)
+      console.error('招待の受諾に失敗:', err)
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [inviteCode, fetchInvitation])
+
+  // 招待コードが変更されたら招待情報を取得
+  useEffect(() => {
+    fetchInvitation()
+  }, [fetchInvitation])
+
+  return {
+    invitation,
+    loading,
+    error,
+    clearError,
+    fetchInvitation,
+    acceptInvitation,
+  }
+}

--- a/src/lib/invitation-api.ts
+++ b/src/lib/invitation-api.ts
@@ -1,153 +1,87 @@
-// パートナー招待API クライアントヘルパー
-// 作成日: 2025-09-07
+'use client'
 
-import { 
+/**
+ * 招待API - リファクタリング版
+ * 新しいサービス層とユーティリティを使用した統合インターフェース
+ * 後方互換性を保ちながら、段階的に新しいアーキテクチャに移行
+ */
+
+// 新しいサービス層とユーティリティをインポート
+import { invitationService } from '@/services/invitationService'
+import {
+  generateInviteUrl,
+  generateQRCodeUrl,
+  validateInviteCode,
+  isInvitationExpired,
+  getTimeUntilExpiration,
+  getErrorMessage,
+  getInvitationStatusText,
+  getInvitationStatusColor,
+  generateInviteCode,
+  calculateExpirationDate,
+} from '@/utils/invitationUtils'
+
+// 型定義をインポート
+import {
+  PartnerInvitation,
   CreateInvitationRequest,
   CreateInvitationResponse,
   GetInvitationResponse,
   AcceptInvitationResponse,
-  GetInvitationsResponse 
 } from './types/partner-invitation'
 
-// 基本的なAPIリクエストヘルパー
-async function apiRequest<T>(
-  url: string,
-  options: RequestInit = {}
-): Promise<T> {
-  const response = await fetch(url, {
-    headers: {
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-    ...options,
-  })
+// ===== API操作（新しいサービス層を使用） =====
 
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({ error: 'ネットワークエラー' }))
-    throw new Error(errorData.error || `HTTP ${response.status}`)
-  }
-
-  return response.json()
-}
-
-// 招待リンク生成
+/**
+ * 招待作成
+ */
 export async function createInvitation(
-  data: CreateInvitationRequest
+  request: CreateInvitationRequest
 ): Promise<CreateInvitationResponse> {
-  return apiRequest<CreateInvitationResponse>('/api/invitations', {
-    method: 'POST',
-    body: JSON.stringify(data),
-  })
+  return invitationService.createInvitation(request)
 }
 
-// 招待一覧取得
-export async function getInvitations(): Promise<GetInvitationsResponse> {
-  return apiRequest<GetInvitationsResponse>('/api/invitations')
+/**
+ * 招待一覧取得
+ */
+export async function getInvitations(): Promise<PartnerInvitation[]> {
+  return invitationService.getInvitations()
 }
 
-// 招待情報取得
+/**
+ * 招待取得
+ */
 export async function getInvitation(
   inviteCode: string
 ): Promise<GetInvitationResponse> {
-  return apiRequest<GetInvitationResponse>(`/api/invitations/${inviteCode}`)
+  return invitationService.getInvitation(inviteCode)
 }
 
-// 招待受諾
+/**
+ * 招待受諾
+ */
 export async function acceptInvitation(
   inviteCode: string
 ): Promise<AcceptInvitationResponse> {
-  return apiRequest<AcceptInvitationResponse>(`/api/invitations/${inviteCode}`, {
-    method: 'POST',
-  })
+  return invitationService.acceptInvitation(inviteCode)
 }
 
-// 招待URL生成ヘルパー
-export function generateInviteUrl(inviteCode: string): string {
-  const baseUrl = typeof window !== 'undefined' 
-    ? window.location.origin 
-    : process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001'
-  return `${baseUrl}/invite/${inviteCode}`
-}
+// ===== ユーティリティ関数（新しいユーティリティ層を使用） =====
 
-// QRコード生成用URL（外部サービス使用）
-export function generateQRCodeUrl(inviteUrl: string): string {
-  // QR Server APIを使用（無料、商用利用可能）
-  const encodedUrl = encodeURIComponent(inviteUrl)
-  return `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodedUrl}`
-}
+// URL生成とQRコード
+export { generateInviteUrl, generateQRCodeUrl }
 
-// 招待コードの有効性チェック
-export function validateInviteCode(code: string): boolean {
-  // UUID v4 からハイフンを除去した32文字の文字列
-  return /^[a-f0-9]{32}$/i.test(code)
-}
+// バリデーション
+export { validateInviteCode, isInvitationExpired }
 
-// 有効期限チェック
-export function isInvitationExpired(expiresAt: string): boolean {
-  return new Date(expiresAt) <= new Date()
-}
+// 時間計算
+export { getTimeUntilExpiration }
 
-// 有効期限までの残り時間を取得
-export function getTimeUntilExpiration(expiresAt: string): {
-  days: number
-  hours: number
-  minutes: number
-  expired: boolean
-} {
-  const now = new Date()
-  const expiry = new Date(expiresAt)
-  const diff = expiry.getTime() - now.getTime()
+// エラーハンドリング
+export { getErrorMessage }
 
-  if (diff <= 0) {
-    return { days: 0, hours: 0, minutes: 0, expired: true }
-  }
+// ステータス表示
+export { getInvitationStatusText, getInvitationStatusColor }
 
-  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
-  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
-  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60))
-
-  return { days, hours, minutes, expired: false }
-}
-
-// エラーハンドリングヘルパー
-export function getErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message
-  }
-  if (typeof error === 'string') {
-    return error
-  }
-  return '予期しないエラーが発生しました'
-}
-
-// 招待ステータスの日本語表示
-export function getInvitationStatusText(status: string): string {
-  switch (status) {
-    case 'pending':
-      return '招待中'
-    case 'accepted':
-      return '受諾済み'
-    case 'expired':
-      return '期限切れ'
-    case 'cancelled':
-      return 'キャンセル済み'
-    default:
-      return '不明'
-  }
-}
-
-// 招待ステータスの色クラス（Tailwind CSS）
-export function getInvitationStatusColor(status: string): string {
-  switch (status) {
-    case 'pending':
-      return 'text-yellow-600 bg-yellow-100'
-    case 'accepted':
-      return 'text-green-600 bg-green-100'
-    case 'expired':
-      return 'text-gray-600 bg-gray-100'
-    case 'cancelled':
-      return 'text-red-600 bg-red-100'
-    default:
-      return 'text-gray-600 bg-gray-100'
-  }
-}
+// 新しいユーティリティ関数
+export { generateInviteCode, calculateExpirationDate }

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,0 +1,99 @@
+'use client'
+
+/**
+ * 汎用APIクライアント
+ * HTTPリクエストの共通処理を担当
+ */
+export class ApiClient {
+  private baseUrl: string
+
+  constructor(baseUrl: string = '') {
+    this.baseUrl = baseUrl
+  }
+
+  /**
+   * 汎用APIリクエストメソッド
+   * 認証ヘッダーの付与、エラーハンドリングを統一
+   */
+  async request<T>(
+    endpoint: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`
+    
+    const defaultHeaders: HeadersInit = {
+      'Content-Type': 'application/json',
+    }
+
+    // 認証トークンがある場合は追加
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('supabase.auth.token')
+      if (token) {
+        defaultHeaders.Authorization = `Bearer ${token}`
+      }
+    }
+
+    const config: RequestInit = {
+      ...options,
+      headers: {
+        ...defaultHeaders,
+        ...options.headers,
+      },
+    }
+
+    try {
+      const response = await fetch(url, config)
+      
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}))
+        throw new Error(
+          errorData.message || 
+          errorData.error || 
+          `HTTP ${response.status}: ${response.statusText}`
+        )
+      }
+
+      return await response.json()
+    } catch (error) {
+      console.error('API Request failed:', { url, error })
+      throw error
+    }
+  }
+
+  /**
+   * GETリクエスト
+   */
+  async get<T>(endpoint: string): Promise<T> {
+    return this.request<T>(endpoint, { method: 'GET' })
+  }
+
+  /**
+   * POSTリクエスト
+   */
+  async post<T>(endpoint: string, data?: any): Promise<T> {
+    return this.request<T>(endpoint, {
+      method: 'POST',
+      body: data ? JSON.stringify(data) : undefined,
+    })
+  }
+
+  /**
+   * PUTリクエスト
+   */
+  async put<T>(endpoint: string, data?: any): Promise<T> {
+    return this.request<T>(endpoint, {
+      method: 'PUT',
+      body: data ? JSON.stringify(data) : undefined,
+    })
+  }
+
+  /**
+   * DELETEリクエスト
+   */
+  async delete<T>(endpoint: string): Promise<T> {
+    return this.request<T>(endpoint, { method: 'DELETE' })
+  }
+}
+
+// シングルトンインスタンス
+export const apiClient = new ApiClient()

--- a/src/services/invitationService.ts
+++ b/src/services/invitationService.ts
@@ -1,0 +1,64 @@
+'use client'
+
+import { apiClient } from './apiClient'
+import {
+  PartnerInvitation,
+  CreateInvitationRequest,
+  CreateInvitationResponse,
+  GetInvitationResponse,
+  AcceptInvitationResponse,
+} from '@/lib/types/partner-invitation'
+
+/**
+ * 招待機能のビジネスロジックを管理するサービス
+ * API呼び出しと招待関連の操作を担当
+ */
+export class InvitationService {
+  /**
+   * 新しい招待を作成
+   */
+  async createInvitation(
+    request: CreateInvitationRequest
+  ): Promise<CreateInvitationResponse> {
+    return apiClient.post<CreateInvitationResponse>('/api/invitations', request)
+  }
+
+  /**
+   * ユーザーの招待一覧を取得
+   */
+  async getInvitations(): Promise<PartnerInvitation[]> {
+    const response = await apiClient.get<{ invitations: PartnerInvitation[] }>('/api/invitations')
+    return response.invitations
+  }
+
+  /**
+   * 特定の招待を取得
+   */
+  async getInvitation(inviteCode: string): Promise<GetInvitationResponse> {
+    return apiClient.get<GetInvitationResponse>(`/api/invitations/${inviteCode}`)
+  }
+
+  /**
+   * 招待を受諾
+   */
+  async acceptInvitation(inviteCode: string): Promise<AcceptInvitationResponse> {
+    return apiClient.post<AcceptInvitationResponse>(`/api/invitations/${inviteCode}`)
+  }
+
+  /**
+   * 招待をキャンセル
+   */
+  async cancelInvitation(invitationId: string): Promise<void> {
+    await apiClient.delete(`/api/invitations/${invitationId}`)
+  }
+
+  /**
+   * 期限切れの招待を削除
+   */
+  async cleanupExpiredInvitations(): Promise<void> {
+    await apiClient.post('/api/invitations/cleanup')
+  }
+}
+
+// シングルトンインスタンス
+export const invitationService = new InvitationService()

--- a/src/utils/invitationUtils.ts
+++ b/src/utils/invitationUtils.ts
@@ -1,0 +1,136 @@
+'use client'
+
+/**
+ * 招待関連のユーティリティ関数
+ * URL生成、バリデーション、フォーマット等の純粋関数を担当
+ */
+
+/**
+ * 招待URL生成ヘルパー
+ */
+export function generateInviteUrl(inviteCode: string): string {
+  const baseUrl = typeof window !== 'undefined' 
+    ? window.location.origin 
+    : process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3001'
+  return `${baseUrl}/invite/${inviteCode}`
+}
+
+/**
+ * QRコード生成用URL（外部サービス使用）
+ */
+export function generateQRCodeUrl(inviteUrl: string): string {
+  // QR Server APIを使用（無料、商用利用可能）
+  const encodedUrl = encodeURIComponent(inviteUrl)
+  return `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodedUrl}`
+}
+
+/**
+ * 招待コードの有効性チェック
+ */
+export function validateInviteCode(code: string): boolean {
+  // UUID v4 からハイフンを除去した32文字の文字列
+  return /^[a-f0-9]{32}$/i.test(code)
+}
+
+/**
+ * 有効期限チェック
+ */
+export function isInvitationExpired(expiresAt: string): boolean {
+  return new Date(expiresAt) <= new Date()
+}
+
+/**
+ * 有効期限までの残り時間を取得
+ */
+export function getTimeUntilExpiration(expiresAt: string): {
+  days: number
+  hours: number
+  minutes: number
+  expired: boolean
+} {
+  const now = new Date()
+  const expiry = new Date(expiresAt)
+  const diff = expiry.getTime() - now.getTime()
+
+  if (diff <= 0) {
+    return { days: 0, hours: 0, minutes: 0, expired: true }
+  }
+
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24))
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60))
+
+  return { days, hours, minutes, expired: false }
+}
+
+/**
+ * エラーハンドリングヘルパー
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  return '予期しないエラーが発生しました'
+}
+
+/**
+ * 招待ステータスの日本語表示
+ */
+export function getInvitationStatusText(status: string): string {
+  switch (status) {
+    case 'pending':
+      return '招待中'
+    case 'accepted':
+      return '受諾済み'
+    case 'expired':
+      return '期限切れ'
+    case 'cancelled':
+      return 'キャンセル済み'
+    default:
+      return '不明'
+  }
+}
+
+/**
+ * 招待ステータスの色クラス（Tailwind CSS）
+ */
+export function getInvitationStatusColor(status: string): string {
+  switch (status) {
+    case 'pending':
+      return 'text-yellow-600 bg-yellow-100'
+    case 'accepted':
+      return 'text-green-600 bg-green-100'
+    case 'expired':
+      return 'text-gray-600 bg-gray-100'
+    case 'cancelled':
+      return 'text-red-600 bg-red-100'
+    default:
+      return 'text-gray-600 bg-gray-100'
+  }
+}
+
+/**
+ * 招待コードを生成（UUID v4ベース）
+ */
+export function generateInviteCode(): string {
+  // UUID v4を生成してハイフンを除去
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'
+    .replace(/[xy]/g, function(c) {
+      const r = Math.random() * 16 | 0
+      const v = c === 'x' ? r : (r & 0x3 | 0x8)
+      return v.toString(16)
+    })
+    .replace(/-/g, '')
+}
+
+/**
+ * 招待の有効期限を計算（デフォルト7日後）
+ */
+export function calculateExpirationDate(daysFromNow: number = 7): string {
+  const expiration = new Date()
+  expiration.setDate(expiration.getDate() + daysFromNow)
+  return expiration.toISOString()
+}


### PR DESCRIPTION
- ApiClientクラスを作成し、HTTP通信の共通処理を統合
- InvitationServiceクラスでビジネスロジックを管理
- invitationUtilsでユーティリティ関数を分離
- useInvitationsフックでReactの状態管理を統合
- invitation-api.tsを新しいアーキテクチャに対応
- 後方互換性を保ちながら段階的移行を実現