### PR TITLE
feat(notifications): improve notification logic for chores

### DIFF
--- a/src/contexts/NotificationContext.tsx
+++ b/src/contexts/NotificationContext.tsx
@@ -128,21 +128,24 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
           switch (payload.eventType) {
             case 'INSERT':
               // 追加者が自分かパートナーかを判定
-              const isAddedByMe = payload.new.created_by === user.id
-              const addedByText = isAddedByMe ? 'あなたが追加しました' : '相手が追加しました'
+              const isAddedByMe = payload.new.owner_id === user.id
+              const addedByText = isAddedByMe ? 'あなたが追加しました' : 'パートナーが追加しました'
               
-              addNotification({
-                title: '新しい家事が追加されました',
-                message: `家事「${payload.new.title}」を${addedByText}`,
-                type: 'info',
-                userId: user.id,
-              })
+              // 自分が追加した場合は通知しない
+              if (!isAddedByMe) {
+                addNotification({
+                  title: '新しい家事が追加されました',
+                  message: `家事「${payload.new.title}」を${addedByText}`,
+                  type: 'info',
+                  userId: user.id,
+                })
+              }
               break
             case 'UPDATE':
-              if (payload.new.completed && !payload.old.completed) {
-                // 完了者が自分かパートナーかを判定
-                const isCompletedByMe = payload.new.completed_by === user.id
-                const completedByText = isCompletedByMe ? 'あなたが完了しました' : '相手が完了しました'
+              if (payload.new.done && !payload.old.done) {
+                // 完了者が自分かパートナーかを判定（owner_idで判断）
+                const isCompletedByMe = payload.new.owner_id === user.id
+                const completedByText = isCompletedByMe ? 'あなたが完了しました' : 'パートナーが完了しました'
                 
                 addNotification({
                   title: '家事が完了しました',


### PR DESCRIPTION
- Skip notifications when user adds their own chore
- Update notification text to use "partner" instead of "相手"
- Use owner_id instead of created_by for notification logic

feat(profile): add display name support in home page

- Fetch and display user's display name from profile
- Fallback to email prefix if display name not available

feat(chores): add partner support in chores management

- Fetch partner_id from profile when creating chores
- Add realtime subscriptions for partner's chores
- Update state management for partner-related chores